### PR TITLE
Add custom content option replacing (sub)title

### DIFF
--- a/lib/achievement_view.dart
+++ b/lib/achievement_view.dart
@@ -20,32 +20,31 @@ class AchievementView {
   final String subTitle;
   final double elevation;
   final OverlayState? overlay;
-
+  final Widget? customContent;
   OverlayEntry? _overlayEntry;
 
-  AchievementView(
-    this._context, {
-    this.elevation = 2,
-    this.onTap,
-    this.listener,
-    this.overlay,
-    this.isCircle = false,
-    this.icon = const Icon(
-      Icons.insert_emoticon,
-      color: Colors.white,
-    ),
-    this.typeAnimationContent = AnimationTypeAchievement.fadeSlideToUp,
-    this.borderRadius,
-    this.iconBorderRadius,
-    this.color = Colors.blueGrey,
-    this.iconBackgroundColor,
-    this.textStyleTitle,
-    this.textStyleSubTitle,
-    this.alignment = Alignment.topCenter,
-    this.duration = const Duration(seconds: 3),
-    this.title = "My Title",
-    this.subTitle = "My subtitle with max 1 line",
-  });
+  AchievementView(this._context,
+      {this.elevation = 2,
+      this.onTap,
+      this.listener,
+      this.overlay,
+      this.isCircle = false,
+      this.icon = const Icon(
+        Icons.insert_emoticon,
+        color: Colors.white,
+      ),
+      this.typeAnimationContent = AnimationTypeAchievement.fadeSlideToUp,
+      this.borderRadius,
+      this.iconBorderRadius,
+      this.color = Colors.blueGrey,
+      this.iconBackgroundColor,
+      this.textStyleTitle,
+      this.textStyleSubTitle,
+      this.alignment = Alignment.topCenter,
+      this.duration = const Duration(seconds: 3),
+      this.title = "My Title",
+      this.subTitle = "My subtitle with max 1 line",
+      this.customContent});
 
   OverlayEntry _buildOverlay() {
     return OverlayEntry(builder: (context) {
@@ -54,6 +53,7 @@ class AchievementView {
         child: AchievementWidget(
           title: title,
           subTitle: subTitle,
+          customContent: customContent,
           duration: duration,
           listener: listener,
           onTap: onTap,

--- a/lib/achievement_widget.dart
+++ b/lib/achievement_widget.dart
@@ -30,6 +30,7 @@ class AchievementWidget extends StatefulWidget {
   final TextStyle? textStyleSubTitle;
   final String title;
   final String subTitle;
+  final Widget? customContent;
 
   const AchievementWidget({
     Key? key,
@@ -52,6 +53,7 @@ class AchievementWidget extends StatefulWidget {
     this.textStyleSubTitle,
     this.title = "",
     this.subTitle = "",
+    this.customContent,
   }) : super(key: key);
 
   @override
@@ -196,16 +198,16 @@ class AchievementWidgetState extends State<AchievementWidget>
             alignment: Alignment.centerLeft,
             child: Padding(
               padding: _buildPaddingContent(),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                mainAxisAlignment: MainAxisAlignment.center,
-                mainAxisSize: MainAxisSize.min,
-                children: <Widget>[
-                  _buildTitle(),
-                  const SizedBox(height: 2),
-                  _buildSubTitle(),
-                ],
-              ),
+              child: widget.customContent ??
+                  Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      mainAxisSize: MainAxisSize.min,
+                      children: <Widget>[
+                        _buildTitle(),
+                        const SizedBox(height: 2),
+                        _buildSubTitle(),
+                      ]),
             ),
           );
         },


### PR DESCRIPTION
This adds an option to pass a Widget (customContent) that will replace the title and subtitle. It's valuable for cases where you may want to have variation in the text of the string, such as RichText and TextSpan.